### PR TITLE
feat(file-upload): increase file size limit to 50MB

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ const { errorHandler } = require('./middleware/errorHandler');
 const app = express();
 
 // Middleware
-app.use(express.json());
+app.use(express.json({ limit: '50mb' }));
+app.use(express.urlencoded({ limit: '50mb', extended: true }));
 app.use(cors());
 app.use('/uploads', express.static('public'));
 

--- a/src/utils/fileUpload.js
+++ b/src/utils/fileUpload.js
@@ -23,7 +23,7 @@ const storage = multer.diskStorage({
 const fileUpload = multer({
   storage,
   limits: {
-    fileSize: process.env.MAX_FILE_SIZE || 5 * 1024 * 1024 // 5MB
+    fileSize: process.env.MAX_FILE_SIZE || 50 * 1024 * 1024 // 50MB
   },
   fileFilter: (req, file, cb) => {
     const allowedTypes = (process.env.ALLOWED_FILE_TYPES || 'image/jpeg,image/jpg,image/png').split(',');


### PR DESCRIPTION
Update the file size limit for both JSON and URL-encoded data in the Express middleware and the file upload utility to handle larger files. This change accommodates larger uploads, improving the application's usability for users who need to upload bigger files.