### PR TITLE
build: add nginx configuration and expose port 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:18
 
+# Install nginx
+RUN apt-get update && apt-get install -y nginx
+
 WORKDIR /app
 
 # Set build arguments for environment variables
@@ -18,6 +21,9 @@ RUN npm install --only=production
 # Create directory for uploaded files
 RUN mkdir -p public
 
+# Copy nginx configuration
+COPY nginx.conf /etc/nginx/nginx.conf
+
 # Set environment variables
 ENV NODE_ENV=production
 ENV PORT=4355
@@ -26,8 +32,12 @@ ENV UPLOADS_BASE_URL=https://face-swap-api.erkansivas.xyz/uploads/
 ENV REPLICATE_API_KEY=${REPLICATE_API_KEY}
 ENV REPLICATE_VERSION=${REPLICATE_VERSION}
 
-# Start the application
-CMD ["npm", "start"]
+# Create startup script
+RUN echo '#!/bin/bash\nnginx\nnpm start' > /app/start.sh
+RUN chmod +x /app/start.sh
 
-# Expose the application port
-EXPOSE 4355
+# Start both nginx and node application
+CMD ["/app/start.sh"]
+
+# Expose both nginx and application ports
+EXPOSE 80 4355

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   faceswap:
     image: erkansivas/faceswap
     ports:
+      - "80:80"
       - "4355:4355"
     volumes:
       - ./public:/app/public

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,49 @@
+user nginx;
+worker_processes auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    # Optimize for large file uploads
+    client_max_body_size 50M;
+    client_body_buffer_size 50M;
+    client_body_timeout 120s;
+    
+    # Proxy settings
+    proxy_connect_timeout 120s;
+    proxy_send_timeout 120s;
+    proxy_read_timeout 120s;
+    proxy_buffer_size 4k;
+    proxy_buffers 4 32k;
+    proxy_busy_buffers_size 64k;
+    proxy_temp_file_write_size 64k;
+
+    # Gzip compression
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+    # Logging
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    server {
+        listen 80;
+        server_name face-swap-api.erkansivas.xyz;
+
+        location / {
+            proxy_pass http://localhost:4355;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}


### PR DESCRIPTION
Add nginx to the Dockerfile for improved request handling and expose port 80 in docker-compose.yml. This change allows the application to serve traffic directly on port 80, simplifying access and enabling better proxy management with nginx.