### PR TITLE
ci: update docker-compose and deploy workflow configurations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
             echo "UPLOADS_BASE_URL=https://face-swap-api.erkansivas.xyz/uploads/" >> .env
             echo "REPLICATE_API_KEY=${{ secrets.REPLICATE_API_KEY }}" >> .env
             echo "REPLICATE_VERSION=${{ secrets.REPLICATE_VERSION }}" >> .env
-            docker-compose down
+            docker-compose down --remove-orphans
             docker-compose pull
+            docker system prune -f
             docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,14 @@ services:
   faceswap:
     image: erkansivas/faceswap
     ports:
-      - "80:80"
+      - "8080:80"
       - "4355:4355"
     volumes:
       - ./public:/app/public
     restart: unless-stopped
+    networks:
+      - faceswap_network
+
+networks:
+  faceswap_network:
+    name: faceswap_network


### PR DESCRIPTION
Update docker-compose.yml to change the port mapping from 80 to 8080 and add a custom network. Modify the deploy.yml workflow to include `--remove-orphans` flag for `docker-compose down` and add `docker system prune -f` to clean up unused Docker objects.